### PR TITLE
 fix the bug of Some weights of XLMRobertaForCausalLM were not initia…

### DIFF
--- a/embedding.py
+++ b/embedding.py
@@ -1,11 +1,11 @@
-from transformers import AutoModelForCausalLM, AutoTokenizer
+from transformers import AutoModelForCausalLM, AutoTokenizer, AutoModel
 import torch
 
 class LocalHuggingFaceEmbeddings:
     def __init__(self, model_path: str):
         self.tokenizer = AutoTokenizer.from_pretrained(model_path)
         self.tokenizer.pad_token = self.tokenizer.eos_token
-        self.model = AutoModelForCausalLM.from_pretrained(model_path)
+        self.model = AutoModel.from_pretrained(model_path)
         self.device = torch.device("cuda" if torch.cuda.is_available() else "mps" if torch.mps.is_available() else "cpu")
         self.model = self.model.to(self.device)
 
@@ -46,5 +46,5 @@ class LocalHuggingFaceEmbeddings:
 
 
 def embedding_function():
-    model_path = "Embedding_Model/e5"  # Replace with your model's path
+    model_path = "multilingual-e5-large"  # Replace with your model's path
     return LocalHuggingFaceEmbeddings(model_path)


### PR DESCRIPTION
 fix the bug of Some weights of XLMRobertaForCausalLM were not initialized from the model checkpoint at multilingual-e5-large and are newly initialized: ['lm_head.bias', 'lm_head.decoder.bias', 'lm_head.dense.bias', 'lm_head.dense.weight', 'lm_head.layer_norm.bias', 'lm_head.layer_norm.weight']
You should probably TRAIN this model on a down-stream task to be able to use it for predictions and inference."
[bugfix/embeddingbug c4c5752]  fix the bug of Some weights of XLMRobertaForCausalLM were not initialized from the model checkpoint at multilingual-e5-large and are newly initialized: ['lm_head.bias', 'lm_head.decoder.bias', 'lm_head.dense.bias', 'lm_head.dense.weight', 'lm_head.layer_norm.bias', 'lm_head.layer_norm.weight'] You should probably TRAIN this model on a down-stream task to be able to use it for predictions and inference.